### PR TITLE
🔨 add support for images with absolute path

### DIFF
--- a/src/process-html.js
+++ b/src/process-html.js
@@ -23,12 +23,12 @@ const processHtml = (file, { srcAttr = 'src', attribute = 'data-src' } = {}) =>
           return false
         }
 
-        const pathImg = path.join(fileDir, src)
+        const pathImg = path.join(src[0] === '/' ? file._base : fileDir, src)
         return validImgExtensions.includes(path.extname(pathImg).toLowerCase())
       })
       .map(el => {
         const src = $(el).attr(srcAttr)
-        const pathImg = path.join(fileDir, src)
+        const pathImg = path.join(src[0] === '/' ? file._base : fileDir, src)
         return processImage(pathImg, src)
       })
 


### PR DESCRIPTION
**Problem ⚠**

currently, you can't use images with an absolute path.  `gulp-lqip-base64` works only with images paths relative to the HTML file.
trying to use an absolute path in the image `src` attribute makes the build fail.


**Fix 🎉**

if an image `src` attribute starts with a slash use the `_base` path instead of the HTML file path